### PR TITLE
Adds basic CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.1
+orbs:
+  node: circleci/node@1.1.6
+jobs:
+  build-and-test:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+workflows:
+    build-and-test:
+      jobs:
+        - build-and-test

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -1,0 +1,7 @@
+import { handler } from './handler';
+
+describe('handler', () => {
+  it('exports a handler function', () => {
+    expect(handler).toBeInstanceOf(Function);
+  });
+});


### PR DESCRIPTION
**What**
Adds very basic CircleCI configuration.

**Why**
So that we can safely start writing code in the project, whilst ensuring our tests are run against each new pull request.

**Anything else?**
 - This is just the default Node CircleCI config for now, we can add in serverless and deployment related bits later on as required.