### PR TITLE
Really, really cleans up temporary deploys

### DIFF
--- a/.github/workflows/cleanup-deploys.yml
+++ b/.github/workflows/cleanup-deploys.yml
@@ -1,5 +1,7 @@
-name: Cleanup branch deploys
-on: [delete]
+name: cleanup-temporary-branch
+on:
+  pull_request:
+    types: [closed]
 
 jobs:
   cleanup:
@@ -12,7 +14,9 @@ jobs:
         with:
           node-version: 12.x
       - run: npm install
-      - run: npm run deploy:cleanup -s ${GITHUB_REF##*/}
+      - run: |
+          GITHUB_HEAD_REF=${{ github.head_ref }} && 
+          npm run deploy:cleanup -- -s ${GITHUB_HEAD_REF##*/}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
**What**  
Uses the `pull_request` `closed` hook to trigger the cleanup deploys action, instead of the `delete` trigger.

**Why**  
The `delete` trigger does not include the reference to the branch that was deleted, and so we cannot use it to work out which deployment to remove.