### PR TITLE
Fixes production deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ workflows:
           filters:
             branches:
               only: master
+          requires:
+            - build-and-test
       - deploy:
           name: deploy-temporary-branch
           stage_name: ${CIRCLE_BRANCH##*/}


### PR DESCRIPTION
**What**  
Waits for `build-and-test` to complete in CircleCI before attempting to deploy to production.

**Why**  
So that we can deploy to production without having to run `npm install` in the `deploy` job, and we don't inadvertently deploy broken code to `master` if it reaches the branch by some untested path (admittedly very unlikely).
