### PR TITLE
Indexes S3 object metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,17 +36,22 @@ jobs:
       stage_name:
         type: string
     steps:
-      - attach_workspace:
-          at: .
-      - aws-cli/setup:
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: sudo npm i -g serverless
+      - run:
+          name: sls deploy
+          command: |
+            npm prune --production
+            sls deploy -s test
+      - node/with-cache:
+          steps:
+            - run: npm i
       - run:
           name: integration-tests
           command: |
-            node lib/index.js &
-            export INTEGRATION_TEST_BASE_URL=http://localhost:5050
+            export INTEGRATION_TEST_BASE_URL=$(echo $(npx serverless info -s test | grep -o -m 1 "https://.*$"))
             npm run test:integration
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,11 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
+            - run: npm i
             - run: sudo npm i -g serverless
+      - run:
+          name: build
+          command: npm run build
       - run:
           name: sls deploy
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,10 @@ jobs:
           steps:
             - run: npm i
             - run: sudo npm i -g serverless
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
       - run:
           name: build
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: integration-tests
           command: |
-            export INTEGRATION_TEST_BASE_URL=$(echo $(npx serverless info -s test | grep -o -m 1 "https://.*$"))
+            export INTEGRATION_TEST_BASE_URL=$(echo $(npx serverless info -s test | grep -o -m 1 "https://.*/test/"))
             npm run test:integration
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   node: circleci/node@1.1.6
   aws-cli: circleci/aws-cli@1.0.0
+  queue: eddiewebb/queue@1.5.0
 jobs:
   build-and-test:
     executor:
@@ -97,6 +98,7 @@ workflows:
               only: master
           requires:
             - permit-deploy-production
+      - queue/block_workflow
       - integration-test:
           name: integration-test
           stage_name: ${CIRCLE_BRANCH##*/}
@@ -106,3 +108,4 @@ workflows:
               ignore: master
           requires:
             - build-and-test
+            - queue/block_workflow

--- a/integration/client/EvidenceStoreClient.ts
+++ b/integration/client/EvidenceStoreClient.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 
 interface EvidenceStoreClientOptions {
   baseUrl: string;
+  authorizationToken: string;
 }
 
 interface Request {
@@ -19,9 +20,11 @@ interface Response {
 
 class EvidenceStoreClient {
   baseUrl: string;
+  authorizationToken?: string;
 
-  constructor({ baseUrl }: EvidenceStoreClientOptions) {
+  constructor({ baseUrl, authorizationToken }: EvidenceStoreClientOptions) {
     this.baseUrl = baseUrl;
+    this.authorizationToken = authorizationToken;
   }
 
   async request({ method, path, body }: Request): Promise<Response> {
@@ -40,6 +43,7 @@ class EvidenceStoreClient {
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
+        'authorization': `Bearer ${this.authorizationToken}`
       },
     });
 

--- a/integration/client/index.ts
+++ b/integration/client/index.ts
@@ -1,5 +1,6 @@
 import EvidenceStoreClient from './EvidenceStoreClient';
 const baseUrl = process.env.INTEGRATION_TEST_BASE_URL;
+const jwt = process.env.INTEGRATION_TEST_JWT;
 
 if (typeof baseUrl !== 'string') {
   console.info([
@@ -8,6 +9,14 @@ if (typeof baseUrl !== 'string') {
   ].join('\n'));
 }
 
+if (typeof jwt !== 'string') {
+  console.info([
+    '[!] There is no JWT set, requests will be sent without authorization.',
+    'This is probably fine locally, if you see this in CI set "INTEGRATION_TEST_JWT".'
+  ].join('\n'));
+}
+
 export default new EvidenceStoreClient({
   baseUrl: baseUrl ?? 'http://localhost:5050',
+  authorizationToken: jwt
 });

--- a/integration/routes/metadata.test.ts
+++ b/integration/routes/metadata.test.ts
@@ -6,29 +6,20 @@ describe('POST /metadata', () => {
     dob: '1999-09-09',
   };
 
-  const expectedSaveResponse = {
-    documentId: expect.any(String),
-    url: expect.any(String),
-    fields: expect.objectContaining({
-      success_action_status: '201',
-      bucket: 'hn-evidence-store-testbucket',
-    }),
-  };
+  it('creates metadata and responds with upload details', async () => {
+    const {
+      statusCode,
+      body
+    } = await client.saveMetadata(metadata);
 
-  it('Saves and gets metadata', async () => {
-    const saveResponse = await client.saveMetadata(metadata);
-    const docId = saveResponse.body.documentId;
-    const getResponse = await client.getMetadata(docId);
-
-    expect(saveResponse.statusCode).toBe(201);
-    expect(saveResponse.body).toStrictEqual(expectedSaveResponse);
-    const expectedGetResponse = {
-      firstName: 'Aidan',
-      dob: '1999-09-09',
-      documentId: docId,
-    };
-
-    expect(getResponse.statusCode).toBe(200);
-    expect(getResponse.body).toStrictEqual(expectedGetResponse);
+    expect(statusCode).toBe(201);
+    expect(body).toStrictEqual({
+      documentId: expect.any(String),
+      url: expect.any(String),
+      fields: expect.objectContaining({
+        success_action_status: '201',
+        bucket: 'hn-evidence-store-test-documents',
+      }),
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "uniformly test -- --testPathPattern=src --collectCoverageFrom=src/**/*",
     "test:watch": "uniformly test -- --testPathPattern=src --watch --coverage=false",
     "test:integration": "uniformly test -- --testPathPattern=integration --coverage=false",
-    "posttest:integration": "aws s3 rm s3://hn-evidence-store-testbucket --recursive",
+    "posttest:integration": "aws s3 rm s3://hn-evidence-store-test-documents --recursive",
     "prelint": "eslint src/",
     "lint": "prettier src/ README.md --write",
     "predeploy": "npm run build && sls create_domain --aws-profile hnserverless -s staging && npm prune --production",

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,7 @@ provider:
         - s3:GetObject
         - s3:DeleteObject
         - s3:ListBucket
-      Resource: '*'
+      Resource: "*"
     - Effect: Allow
       Action:
         - es:ESHttpPost
@@ -24,19 +24,19 @@ provider:
         - es:ESHttpDelete
         - es:ESHttpGet
       Resource:
-        - { 'Fn::GetAtt': ['ElasticSearchInstance', 'DomainArn'] }
+        - { "Fn::GetAtt": ["ElasticSearchInstance", "DomainArn"] }
         - {
-            'Fn::Join':
+            "Fn::Join":
               [
-                '',
-                ['Fn::GetAtt': ['ElasticSearchInstance', 'DomainArn'], '/*'],
+                "",
+                ["Fn::GetAtt": ["ElasticSearchInstance", "DomainArn"], "/*"],
               ],
           }
   environment:
-    BUCKET_NAME: '${self:service}-${self:provider.stage}-documents'
+    BUCKET_NAME: "${self:service}-${self:provider.stage}-documents"
     ES_CLIENT_ENDPOINT:
       Fn::Join:
-        ['', ['https://', Fn::GetAtt: [ElasticSearchInstance, DomainEndpoint]]]
+        ["", ["https://", Fn::GetAtt: [ElasticSearchInstance, DomainEndpoint]]]
     ES_INDEX_NAME: documents
 
 plugins:
@@ -87,7 +87,7 @@ functions:
         - authorizer.js
         - node_modules/**
     environment:
-      ALLOWED_GROUPS: 'housingneeds-singleview-beta'
+      ALLOWED_GROUPS: "housingneeds-singleview-beta"
       JWT_SECRET: ${ssm:/common/hackney-jwt-secret}
 
 resources:
@@ -119,14 +119,14 @@ resources:
           ZoneAwarenessEnabled: false
         ElasticsearchVersion: 7.4
         AccessPolicies:
-          Version: '2012-10-17'
+          Version: "2012-10-17"
           Statement:
             Action:
               - es:ESHttpGet
               - es:ESHttpPut
               - es:ESHttpPost
               - es:ESHttpHead
-            Principal: '*'
+            Principal: "*"
             Effect: Allow
 
 custom:
@@ -134,14 +134,15 @@ custom:
     hn-evidence-store-authorizer:
       name: ${self:service}-authorizer
       type: request
-      identitySource: ''
+      identitySource: ""
       resultTtlInSeconds: 0
   domains:
     base: evidence-store.api.hackney.gov.uk
+    test: test-${self:custom.domains.base}
     staging: staging-${self:custom.domains.base}
     prod: ${self:custom.domains.base}
   customDomain:
     domainName: ${self:custom.domains.${self:provider.stage}, '${env:TEMP_STAGING_NAME, 'TEMP'}-${self:custom.domains.base}'}
-    basePath: ''
-    certificateName: '*.api.hackney.gov.uk'
+    basePath: ""
+    certificateName: "*.api.hackney.gov.uk"
     createRoute53Record: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -111,23 +111,13 @@ resources:
         EBSOptions:
           EBSEnabled: true
           VolumeType: gp2
-          VolumeSize: 10
+          VolumeSize: ${self:custom.elasticsearch.${self:provider.stage}.volumeSize}
         ElasticsearchClusterConfig:
-          InstanceType: t2.small.elasticsearch
-          InstanceCount: 1
+          InstanceType: ${self:custom.elasticsearch.${self:provider.stage}.instanceSize}
+          InstanceCount: ${self:custom.elasticsearch.${self:provider.stage}.instanceCount}
           DedicatedMasterEnabled: false
           ZoneAwarenessEnabled: false
         ElasticsearchVersion: 7.4
-        AccessPolicies:
-          Version: "2012-10-17"
-          Statement:
-            Action:
-              - es:ESHttpGet
-              - es:ESHttpPut
-              - es:ESHttpPost
-              - es:ESHttpHead
-            Principal: "*"
-            Effect: Allow
 
 custom:
   authorizer:
@@ -146,3 +136,16 @@ custom:
     basePath: ""
     certificateName: "*.api.hackney.gov.uk"
     createRoute53Record: false
+  elasticsearch:
+    test:
+      instanceSize: t2.small.elasticsearch
+      instanceCount: 1
+      volumeSize: 10
+    staging:
+      instanceSize: t2.small.elasticsearch
+      instanceCount: 1
+      volumeSize: 10
+    prod:
+      instanceSize: t2.small.elasticsearch
+      instanceCount: 1
+      volumeSize: 10

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -10,6 +10,7 @@ import {
   FindDocuments,
   CreateDownloadUrl,
 } from './use-cases';
+import GetIndexedMetadataUseCase from './use-cases/GetIndexedMetadata';
 
 export interface Container {
   logger: Logger;
@@ -81,7 +82,12 @@ class DefaultContainer implements Container {
 
   get findDocuments() {
     return new FindDocuments({
-      logger: this.logger,
+      elasticsearchGateway: this.elasticsearchGateway,
+    });
+  }
+
+  get getIndexedMetadata() {
+    return new GetIndexedMetadataUseCase({
       elasticsearchGateway: this.elasticsearchGateway,
     });
   }

--- a/src/gateways/S3Gateway.test.ts
+++ b/src/gateways/S3Gateway.test.ts
@@ -62,6 +62,27 @@ describe('S3Gateway', () => {
     expect(result).toStrictEqual(expectedData);
   });
 
+  it('sets the correct policy conditions on the upload URL', async () => {
+    const documentId = '123';
+    const s3Gateway = new S3Gateway({
+      logger: new NoOpLogger(),
+      client,
+      bucketName: 'testBucket'
+    });
+
+    await s3Gateway.createUrl(documentId);
+    expect(client.createPresignedPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Conditions: expect.arrayContaining([
+          ['starts-with', '$key', `${documentId}/`],
+          { 'X-Amz-Server-Side-Encryption': 'AES256' },
+          ['starts-with', '$X-Amz-Meta-Description', ''],
+        ])
+      }),
+      expect.any(Function)
+    );
+  });
+
   it('can get a document by id', async () => {
     const documentId = '123';
     const expectedDocument = {

--- a/src/gateways/S3Gateway.test.ts
+++ b/src/gateways/S3Gateway.test.ts
@@ -126,4 +126,26 @@ describe('S3Gateway', () => {
       'https://s3.eu-west-2.amazonaws.com/bucket/filename.txt'
     );
   });
+
+  it('can get metadata from S3 object', async () => {
+    const expectedObject = {
+      description: "My passport"
+    }
+
+    client.headObject = jest.fn(() => ({
+      promise: () =>
+        Promise.resolve({
+          Metadata: expectedObject,
+        }),
+    }));
+
+    const gateway = new S3Gateway({
+      logger: new NoOpLogger(),
+      client,
+      bucketName: 'testBucket'
+    });
+
+    const result = await gateway.getObjectMetadata('123/Passport.jpg');
+    expect(result).toStrictEqual(expectedObject);
+  });
 });

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -95,6 +95,6 @@ export class S3Gateway {
       })
       .promise();
 
-    return metadata.Metadata ?? {};
+    return metadata.Metadata || {};
   }
 }

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -46,6 +46,7 @@ export class S3Gateway {
             { bucket: this.bucketName },
             ['starts-with', '$key', `${documentId}/`],
             { 'X-Amz-Server-Side-Encryption': 'AES256' },
+            ['starts-with', '$X-Amz-Meta-Description', '']
           ],
         },
         (err, data) => {

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -86,4 +86,15 @@ export class S3Gateway {
       Expires: expiresIn
     });
   }
+
+  async getObjectMetadata(key: string): Promise<Record<string, string>> {
+    const metadata = await this.client
+      .headObject({
+        Bucket: this.bucketName,
+        Key: key
+      })
+      .promise();
+
+    return metadata.Metadata ?? {};
+  }
 }

--- a/src/routes/get-metadata.test.ts
+++ b/src/routes/get-metadata.test.ts
@@ -1,6 +1,7 @@
 jest.mock('../dependencies');
 import fastify from 'fastify';
 import { createEndpoint } from './get-metadata';
+import GetIndexedMetadataUseCase from '../use-cases/GetIndexedMetadata';
 
 describe('GET /documentId', () => {
   const expectedResponse = {
@@ -9,18 +10,19 @@ describe('GET /documentId', () => {
     dob: '1990-01-01',
   };
 
-  const getMetadata = {
+  const getIndexedMetadata = {
     execute: jest.fn(() => expectedResponse),
-  };
+  } as unknown as GetIndexedMetadataUseCase;
 
   const app = fastify();
-  app.route(createEndpoint({ getMetadata }));
+  app.route(createEndpoint({ getIndexedMetadata }));
 
   it('can get metadata', async () => {
     const response = await app.inject({
       method: 'GET',
       url: '/123',
     });
+
     expect(response.body).toStrictEqual(JSON.stringify(expectedResponse));
     expect(response.statusCode).toBe(200);
   });

--- a/src/routes/get-metadata.ts
+++ b/src/routes/get-metadata.ts
@@ -1,34 +1,30 @@
 import dependencies from '../dependencies';
 import { FastifyRequest, RouteOptions, DefaultQuery } from 'fastify';
 import { IncomingMessage } from 'http';
-import { GetMetadata } from '../use-cases';
+import GetIndexedMetadataUseCase from '../use-cases/GetIndexedMetadata';
 
 interface EndpointDependencies {
-  getMetadata: GetMetadata;
+  getIndexedMetadata: GetIndexedMetadataUseCase;
 }
 
 interface Params {
   documentId: string;
 }
 
-const createEndpoint = ({
-  getMetadata,
-}: EndpointDependencies): RouteOptions => ({
+const createEndpoint = ({ getIndexedMetadata }: EndpointDependencies): RouteOptions => ({
   method: 'GET',
   url: '/:documentId',
-  handler: async (
-    req: FastifyRequest<IncomingMessage, DefaultQuery, Params>,
-    reply
-  ) => {
-    const result = await getMetadata.execute({
-      documentId: req.params.documentId,
+  handler: async (req: FastifyRequest<IncomingMessage, DefaultQuery, Params>, reply) => {
+    const result = await getIndexedMetadata.execute({
+      documentId: req.params.documentId
     });
+
     reply.status(200).send(result);
   },
 });
 
 export default createEndpoint({
-  getMetadata: dependencies.getMetadata,
+  getIndexedMetadata: dependencies.getIndexedMetadata,
 });
 
 export { createEndpoint };

--- a/src/s3/objectCreated.test.ts
+++ b/src/s3/objectCreated.test.ts
@@ -39,6 +39,7 @@ describe('ObjectCreated handler', () => {
       expect.objectContaining({
         documentId: 'abcd12345',
         filename: 'document.jpg',
+        objectKey: 'abcd12345/document.jpg'
       })
     );
   });

--- a/src/s3/objectCreated.ts
+++ b/src/s3/objectCreated.ts
@@ -40,6 +40,7 @@ const createHandler: (container: Container) => S3Handler = ({
           await indexer.execute({
             documentId: getDocumentIdFromKey(key),
             filename: getFilenameFromKey(key),
+            objectKey: key
           });
           logger.log('successfully indexed');
         } catch (err) {

--- a/src/use-cases/GetIndexedMetadata.test.ts
+++ b/src/use-cases/GetIndexedMetadata.test.ts
@@ -1,0 +1,26 @@
+import GetIndexedMetadata from './GetIndexedMetadata';
+import { ElasticsearchGateway } from '../gateways';
+
+describe('Get Indexed Metadata Use Case', () => {
+  const expectedMetadata = {
+    documentId: '123',
+    firstName: 'Andrew',
+    dob: '1999-09-09',
+    description: 'This is a description',
+    filename: 'passport.jpg'
+  };
+
+  const usecase = new GetIndexedMetadata({
+    elasticsearchGateway: {
+      getByDocumentId: jest.fn(() => Promise.resolve(expectedMetadata)),
+    } as unknown as ElasticsearchGateway
+  });
+
+  it('retrieves metadata for a given document id', async () => {
+    const result = await usecase.execute({
+      documentId: expectedMetadata.documentId,
+    });
+
+    expect(result).toStrictEqual(expectedMetadata);
+  });
+});

--- a/src/use-cases/GetIndexedMetadata.ts
+++ b/src/use-cases/GetIndexedMetadata.ts
@@ -1,0 +1,24 @@
+import { UseCase } from './UseCase';
+import { DocumentMetadata } from '../domain';
+import { ElasticsearchGateway } from '../gateways';
+
+interface GetMetadataDependencies {
+  elasticsearchGateway: ElasticsearchGateway;
+}
+
+interface GetIndexedMetadataQuery {
+  documentId: string;
+}
+
+export default class GetIndexedMetadataUseCase implements UseCase<GetIndexedMetadataQuery, DocumentMetadata> {
+  es: ElasticsearchGateway;
+
+  constructor({ elasticsearchGateway }: GetMetadataDependencies) {
+    this.es = elasticsearchGateway;
+  }
+
+  async execute({ documentId }: GetIndexedMetadataQuery): Promise<DocumentMetadata> {
+    const metadata = await this.es.getByDocumentId(documentId);
+    return metadata;
+  }
+}

--- a/src/use-cases/GetMetadata.test.ts
+++ b/src/use-cases/GetMetadata.test.ts
@@ -2,23 +2,34 @@ import GetMetadata from './GetMetadata';
 import { S3Gateway } from '../gateways';
 
 describe('Get Metadata Use Case', () => {
-  const expectedDocument = {
+  const objectMetadata = {
+    description: 'My passport'
+  };
+
+  const predfinedMetadata = {
     firstName: 'Andrew',
     dob: '1999-09-09',
     documentId: '123',
   };
 
+  const expectedDocument = {
+    ...objectMetadata,
+    ...predfinedMetadata
+  };
+
   const usecase = new GetMetadata({
-    s3Gateway: ({
-      get: jest.fn(() => Promise.resolve(expectedDocument)),
-    } as unknown) as S3Gateway,
+    s3Gateway: {
+      get: jest.fn(() => Promise.resolve(predfinedMetadata)),
+      getObjectMetadata: jest.fn(() => Promise.resolve(objectMetadata))
+    } as unknown as S3Gateway
   });
 
-  it('gets a document by id', async () => {
+  it('retrieves metadata from the S3 object', async () => {
     const result = await usecase.execute({
       documentId: expectedDocument.documentId,
+      objectKey: `${expectedDocument.documentId}/passport.jpg`
     });
 
-    expect(result).toBe(expectedDocument);
-  });
+    expect(result).toStrictEqual(expectedDocument);
+  })
 });

--- a/src/use-cases/GetMetadata.ts
+++ b/src/use-cases/GetMetadata.ts
@@ -8,6 +8,7 @@ interface GetMetadataDependencies {
 
 interface GetMetadataQuery {
   documentId: string;
+  objectKey: string;
 }
 
 export default class GetMetadataUseCase
@@ -18,7 +19,18 @@ export default class GetMetadataUseCase
     this.metadata = s3Gateway;
   }
 
-  async execute({ documentId }: GetMetadataQuery): Promise<DocumentMetadata> {
-    return await this.metadata.get(documentId);
+  async execute({ documentId, objectKey }: GetMetadataQuery): Promise<DocumentMetadata> {
+    const [
+      objectMetadata,
+      predefinedMetadata
+    ] = await Promise.all([
+      this.metadata.getObjectMetadata(objectKey),
+      this.metadata.get(documentId)
+    ]);
+
+    return {
+      ...objectMetadata,
+      ...predefinedMetadata
+    }
   }
 }

--- a/src/use-cases/IndexDocument.test.ts
+++ b/src/use-cases/IndexDocument.test.ts
@@ -16,8 +16,8 @@ describe('IndexDocument', () => {
   let getMetadata: GetMetadata;
 
   beforeEach(() => {
-    es = { index: jest.fn() };
-    getMetadata = { execute: jest.fn(() => Promise.resolve(expectedMetadata)) };
+    es = { index: jest.fn() } as unknown as ElasticsearchGateway;
+    getMetadata = { execute: jest.fn(() => Promise.resolve(expectedMetadata)) } as unknown as GetMetadata;
     usecase = new IndexDocument({
       logger: new NoOpLogger(),
       getMetadata,
@@ -26,10 +26,25 @@ describe('IndexDocument', () => {
   });
 
   describe('when called with a valid documentId', () => {
+    it('passes through the object key to fetch metadata', async () => {
+      await usecase.execute({
+        documentId: 'tewg61a',
+        filename: 'passport.jpg',
+        objectKey: 'tewg61a/passport.jpg'
+      });
+
+      expect(getMetadata.execute).toHaveBeenLastCalledWith({
+        documentId: 'tewg61a',
+        filename: 'passport.jpg',
+        objectKey: 'tewg61a/passport.jpg'
+      });
+    });
+
     it('indexes existing metadata', async () => {
       await usecase.execute({
         documentId: 'tewg61a',
-        filename: 'cat.jpg'
+        filename: 'passport.jpg',
+        objectKey: 'tewg61a/passport.jpg'
       });
       expect(es.index).toHaveBeenCalledWith(expectedMetadata);
     });
@@ -47,10 +62,18 @@ describe('IndexDocument', () => {
     it('throws UnknownDocumentError', async () => {
       await expect(usecase.execute({
         documentId: 'UNKNOWN',
-        filename: 'UNKNOWN/readme.txt'
+        filename: 'readme.txt',
+        objectKey: 'UNKNOWN/readme.txt'
       })).rejects.toThrow(
         UnknownDocumentError
       );
+      await expect(
+        usecase.execute({
+          documentId: 'UNKNOWN',
+          filename: 'passport.jpg',
+          objectKey: 'tewg61a/passport.jpg'
+        })
+      ).rejects.toThrow(UnknownDocumentError);
     });
   });
 });

--- a/src/use-cases/IndexDocument.test.ts
+++ b/src/use-cases/IndexDocument.test.ts
@@ -35,7 +35,6 @@ describe('IndexDocument', () => {
 
       expect(getMetadata.execute).toHaveBeenLastCalledWith({
         documentId: 'tewg61a',
-        filename: 'passport.jpg',
         objectKey: 'tewg61a/passport.jpg'
       });
     });
@@ -43,9 +42,10 @@ describe('IndexDocument', () => {
     it('indexes existing metadata', async () => {
       await usecase.execute({
         documentId: 'tewg61a',
-        filename: 'passport.jpg',
-        objectKey: 'tewg61a/passport.jpg'
+        filename: 'cat.jpg',
+        objectKey: 'tewg61a/cat.jpg'
       });
+
       expect(es.index).toHaveBeenCalledWith(expectedMetadata);
     });
   });
@@ -60,13 +60,6 @@ describe('IndexDocument', () => {
     });
 
     it('throws UnknownDocumentError', async () => {
-      await expect(usecase.execute({
-        documentId: 'UNKNOWN',
-        filename: 'readme.txt',
-        objectKey: 'UNKNOWN/readme.txt'
-      })).rejects.toThrow(
-        UnknownDocumentError
-      );
       await expect(
         usecase.execute({
           documentId: 'UNKNOWN',

--- a/src/use-cases/IndexDocument.ts
+++ b/src/use-cases/IndexDocument.ts
@@ -12,6 +12,7 @@ interface IndexDocumentDependencies {
 interface IndexDocumentCommand {
   documentId: string;
   filename: string;
+  objectKey: string;
 }
 
 export default class IndexDocumentUseCase
@@ -30,11 +31,17 @@ export default class IndexDocumentUseCase
     this.es = elasticsearchGateway;
   }
 
-  async execute({ documentId, filename }: IndexDocumentCommand): Promise<void> {
-    this.logger.mergeContext({ documentId }).log('indexing document');
+  async execute({ documentId, filename, objectKey }: IndexDocumentCommand): Promise<void> {
+    this.logger
+      .mergeContext({ documentId, filename, objectKey })
+      .log('indexing document');
 
     try {
-      const metadata = await this.getMetadata.execute({ documentId });
+      const metadata = await this.getMetadata.execute({
+        documentId,
+        objectKey
+      });
+
       await this.es.index({ ...metadata, filename });
     } catch (err) {
       this.logger.error(err).log('indexing failed');

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -4,3 +4,4 @@ export { default as GetMetadata } from './GetMetadata';
 export { default as SaveMetadata } from './SaveMetadata';
 export { default as FindDocuments } from './FindDocuments';
 export { default as CreateDownloadUrl } from './CreateDownloadUrl';
+export { default as GetIndexedMetadata } from './GetIndexedMetadata';


### PR DESCRIPTION
**What**  
Indexes metadata on the S3 objects alongside the metadata from the metadata file.

**Why**  
For document uploads we need to be able to set a description of the document at the time of uploading it, this allows a file description to be added (or any other metadata for other, future, use cases) and indexed.

