### PR TITLE
Get document contents [1/2] - docs and indexing

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: "3.0.0"
 info:
   title: Evidence Store API
   version: 1.0.0
@@ -18,26 +18,41 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/metadata'
+                $ref: "#/components/schemas/metadata"
               example:
                 {
-                  'documentId': 'kjsak2',
-                  'firstName': 'The name',
-                  'dob': '1999-01-01',
+                  "documentId": "kjsak2",
+                  "firstName": "The name",
+                  "dob": "1999-01-01",
                 }
   /{documentId}:
     get:
       operationId: get-metadata
       summary: Gets a document from S3 using the document id
       parameters:
-        - $ref: '#/components/parameters/documentId'
+        - $ref: "#/components/parameters/documentId"
       responses:
         200:
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/metadata'
+                $ref: "#/components/schemas/metadata"
+  /{documentId}/contents:
+    get:
+      operationId: get-document-contents
+      summary: >
+        Gets the contents of a document from S3 using the document id
+      parameters:
+        - $ref: "#/components/parameters/documentId"
+      responses:
+        302:
+          description: Found
+          headers:
+            Location:
+              schema:
+                type: string
+              description: The location of the document contents
   /search:
     post:
       operationId: find-documents
@@ -47,7 +62,7 @@ paths:
           application/json:
             schema:
               type: object
-              example: { 'firstName': 'Toaster', 'dob': '1999-01-01' }
+              example: { "firstName": "Toaster", "dob": "1999-01-01" }
       responses:
         200:
           description: Documents
@@ -55,21 +70,21 @@ paths:
             application/json:
               example:
                 {
-                  'documents':
+                  "documents":
                     [
                       {
-                        'documentId': '1',
-                        'index': 'documents',
-                        'score': 0.3,
-                        'metadata':
-                          { 'firstName': 'Toaster', 'dob': '1999-01-01' },
+                        "documentId": "1",
+                        "index": "documents",
+                        "score": 0.3,
+                        "metadata":
+                          { "firstName": "Toaster", "dob": "1999-01-01" },
                       },
                       {
-                        'documentId': '2',
-                        'index': 'documents',
-                        'score': 0.5,
-                        'metadata':
-                          { 'firstName': 'Toaster', 'dob': '1999-01-01' },
+                        "documentId": "2",
+                        "index": "documents",
+                        "score": 0.5,
+                        "metadata":
+                          { "firstName": "Toaster", "dob": "1999-01-01" },
                       },
                     ],
                 }

--- a/src/s3/objectCreated.test.ts
+++ b/src/s3/objectCreated.test.ts
@@ -37,6 +37,7 @@ describe('ObjectCreated handler', () => {
     expect(dependencies.indexDocument.execute).toHaveBeenCalledWith(
       expect.objectContaining({
         documentId: 'abcd12345',
+        filename: 'document.jpg',
       })
     );
   });

--- a/src/s3/objectCreated.ts
+++ b/src/s3/objectCreated.ts
@@ -10,6 +10,7 @@ interface HandlerDependencies {
 
 const isMetadataFile = (key: string) => key.endsWith('.json');
 const getDocumentIdFromKey = (key: string) => key.split('/')[0];
+const getFilenameFromKey = (key: string) => key.split('/').reverse()[0];
 
 const createHandler: (container: Container) => S3Handler = ({
   logger,
@@ -36,7 +37,10 @@ const createHandler: (container: Container) => S3Handler = ({
       if (!isMetadataFile(key)) {
         try {
           logger.log('indexing');
-          await indexer.execute({ documentId: getDocumentIdFromKey(key) });
+          await indexer.execute({
+            documentId: getDocumentIdFromKey(key),
+            filename: getFilenameFromKey(key),
+          });
           logger.log('successfully indexed');
         } catch (err) {
           logger.error(err);

--- a/src/use-cases/IndexDocument.test.ts
+++ b/src/use-cases/IndexDocument.test.ts
@@ -8,6 +8,7 @@ describe('IndexDocument', () => {
     documentId: 'tewg61a',
     some: 'key',
     another: 'value',
+    filename: 'cat.jpg'
   };
 
   let usecase: IndexDocument;
@@ -26,7 +27,10 @@ describe('IndexDocument', () => {
 
   describe('when called with a valid documentId', () => {
     it('indexes existing metadata', async () => {
-      await usecase.execute({ documentId: 'tewg61a' });
+      await usecase.execute({
+        documentId: 'tewg61a',
+        filename: 'cat.jpg'
+      });
       expect(es.index).toHaveBeenCalledWith(expectedMetadata);
     });
   });
@@ -41,7 +45,10 @@ describe('IndexDocument', () => {
     });
 
     it('throws UnknownDocumentError', async () => {
-      await expect(usecase.execute({ documentId: 'UNKNOWN' })).rejects.toThrow(
+      await expect(usecase.execute({
+        documentId: 'UNKNOWN',
+        filename: 'UNKNOWN/readme.txt'
+      })).rejects.toThrow(
         UnknownDocumentError
       );
     });

--- a/src/use-cases/IndexDocument.ts
+++ b/src/use-cases/IndexDocument.ts
@@ -11,6 +11,7 @@ interface IndexDocumentDependencies {
 
 interface IndexDocumentCommand {
   documentId: string;
+  filename: string;
 }
 
 export default class IndexDocumentUseCase
@@ -29,12 +30,12 @@ export default class IndexDocumentUseCase
     this.es = elasticsearchGateway;
   }
 
-  async execute({ documentId }: IndexDocumentCommand): Promise<void> {
+  async execute({ documentId, filename }: IndexDocumentCommand): Promise<void> {
     this.logger.mergeContext({ documentId }).log('indexing document');
 
     try {
       const metadata = await this.getMetadata.execute({ documentId });
-      await this.es.index(metadata);
+      await this.es.index({ ...metadata, filename });
     } catch (err) {
       this.logger.error(err).log('indexing failed');
       throw err;


### PR DESCRIPTION
**What**  
Adds documentation for the get contents endpoint, indexes the filename of objects that are uploaded.

**Why**  
Capturing the filename allows us to fetch the file contents later on by reconstructing the S3 object key and generating the appropriate signed URL for the object.

**Anything else?**
- Have you added any new third-party libraries? Nope.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? Non.
