### PR TITLE
Get document contents [2/2] - implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@1.1.6
+  aws-cli: circleci/aws-cli@1.0.0
 jobs:
   build-and-test:
     executor:
@@ -20,12 +21,12 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - 'integration'
-            - 'lib'
-            - 'node_modules'
-            - 'package.json'
-            - 'setupTests.ts'
-            - '.uniformlyrc'
+            - "integration"
+            - "lib"
+            - "node_modules"
+            - "package.json"
+            - "setupTests.ts"
+            - ".uniformlyrc"
 
   integration-test:
     executor:
@@ -36,6 +37,10 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - aws-cli/setup:
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
       - run:
           name: integration-tests
           command: |

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -8,6 +8,7 @@ import {
   GetMetadata,
   SaveMetadata,
   FindDocuments,
+  CreateDownloadUrl,
 } from './use-cases';
 
 export interface Container {
@@ -82,6 +83,13 @@ class DefaultContainer implements Container {
     return new FindDocuments({
       logger: this.logger,
       elasticsearchGateway: this.elasticsearchGateway,
+    });
+  }
+
+  get createDownloadUrl() {
+    return new CreateDownloadUrl({
+      logger: this.logger,
+      s3Gateway: this.s3Gateway,
     });
   }
 }

--- a/src/gateways/S3Gateway.test.ts
+++ b/src/gateways/S3Gateway.test.ts
@@ -14,6 +14,9 @@ describe('S3Gateway', () => {
           },
         })
       ),
+      getSignedUrlPromise: jest.fn(() => Promise.resolve(
+        'https://s3.eu-west-2.amazonaws.com/bucket/filename.txt'
+      )),
     };
   });
 
@@ -81,5 +84,25 @@ describe('S3Gateway', () => {
 
     const result = await s3Gateway.get(documentId);
     expect(result).toStrictEqual(expectedDocument);
+  });
+
+  it('creates a signed download url', async () => {
+    const gateway = new S3Gateway({
+      logger: new NoOpLogger(),
+      client,
+      bucketName: 'bucket'
+    });
+
+    const signedUrl = await gateway.createDownloadUrl('bucket/filename.txt', 30);
+
+    expect(client.getSignedUrlPromise).toHaveBeenCalledWith('getObject', {
+      Bucket: 'bucket',
+      Key: 'bucket/filename.txt',
+      Expires: 30
+    });
+
+    expect(signedUrl).toBe(
+      'https://s3.eu-west-2.amazonaws.com/bucket/filename.txt'
+    );
   });
 });

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -72,4 +72,17 @@ export class S3Gateway {
 
     return JSON.parse(object.Body.toString());
   }
+
+  async createDownloadUrl(key: string, expiresIn: number): Promise<string> {
+    this.logger.mergeContext({
+      key,
+      expiresIn
+    }).log('creating S3 signed url');
+
+    return await this.client.getSignedUrlPromise('getObject', {
+      Bucket: this.bucketName,
+      Key: key,
+      Expires: expiresIn
+    });
+  }
 }

--- a/src/routes/get-document-contents.test.ts
+++ b/src/routes/get-document-contents.test.ts
@@ -1,0 +1,42 @@
+import fastify from 'fastify';
+import { createEndpoint } from './get-document-contents';
+import { GetMetadata, CreateDownloadUrl } from '../use-cases';
+import { NoOpLogger } from '../logging/NoOpLogger';
+
+describe('GET /{documentId}/contents', () => {
+  const expectedMetadataResponse = {
+    documentId: 'ahw82u',
+    filename: 'jam.png'
+  };
+
+  const expectedDownloadRepsonse = {
+    downloadUrl: 'https://s3.download.url/jam.png',
+  };
+
+  const getMetadata = {
+    execute: jest.fn(() => expectedMetadataResponse),
+  } as unknown as GetMetadata;
+
+  const createDownloadUrl = {
+    execute: jest.fn(() => expectedDownloadRepsonse)
+  } as unknown as CreateDownloadUrl;
+
+  const app = fastify();
+  app.route(createEndpoint({
+    logger: new NoOpLogger(),
+    getMetadata,
+    createDownloadUrl
+  }));
+
+  it('redirects to the expected download URL', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/ahw82u/contents',
+    });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe(
+      expectedDownloadRepsonse.downloadUrl
+    );
+  });
+});

--- a/src/routes/get-document-contents.ts
+++ b/src/routes/get-document-contents.ts
@@ -1,0 +1,54 @@
+import dependencies from '../dependencies';
+import { FastifyRequest, RouteOptions, DefaultQuery } from 'fastify';
+import { IncomingMessage } from 'http';
+import { GetMetadata, CreateDownloadUrl } from '../use-cases';
+import { Logger } from '../logging';
+
+interface EndpointDependencies {
+  logger: Logger;
+  getMetadata: GetMetadata;
+  createDownloadUrl: CreateDownloadUrl;
+}
+
+interface Params {
+  documentId: string;
+}
+
+type Request = FastifyRequest<IncomingMessage, DefaultQuery, Params>;
+
+const createEndpoint = ({
+  logger,
+  getMetadata,
+  createDownloadUrl,
+}: EndpointDependencies): RouteOptions => ({
+  method: 'GET',
+  url: '/:documentId/contents',
+  handler: async (req: Request, reply) => {
+    const { documentId, filename } = await getMetadata.execute({
+      documentId: req.params.documentId,
+    });
+
+    logger.mergeContext({ documentId, filename });
+
+    if (filename && filename.length > 0) {
+      const { downloadUrl } = await createDownloadUrl.execute({
+        filename,
+        documentId
+      });
+
+      logger.log('redirecting to download url');
+      reply.redirect(302, downloadUrl);
+    } else {
+      logger.log('no filename set in metadata');
+      reply.status(400).send();
+    }
+  },
+});
+
+export default createEndpoint({
+  logger: dependencies.logger,
+  getMetadata: dependencies.getMetadata,
+  createDownloadUrl: dependencies.createDownloadUrl,
+});
+
+export { createEndpoint };

--- a/src/use-cases/CreateDownloadUrl.test.ts
+++ b/src/use-cases/CreateDownloadUrl.test.ts
@@ -1,0 +1,23 @@
+import CreateDownloadUrl from './CreateDownloadUrl';
+import { S3Gateway } from '../gateways';
+import { NoOpLogger } from '../logging/NoOpLogger';
+
+describe('Create Download URL', () => {
+  const expectedDownloadUrl = 'https://download.url/anw7qk/super.jpg';
+
+  const usecase = new CreateDownloadUrl({
+    logger: new NoOpLogger(),
+    s3Gateway: ({
+      createDownloadUrl: jest.fn(() => Promise.resolve(expectedDownloadUrl)),
+    } as unknown) as S3Gateway,
+  });
+
+  it('creates a suitable download URL', async () => {
+    const result = await usecase.execute({
+      filename: 'super.jpg',
+      documentId: 'anw7qk',
+    });
+
+    expect(result.downloadUrl).toBe(expectedDownloadUrl);
+  });
+});

--- a/src/use-cases/CreateDownloadUrl.ts
+++ b/src/use-cases/CreateDownloadUrl.ts
@@ -18,16 +18,27 @@ interface CreateDownloadUrlResponse {
 
 export default class CreateDownloadUrlUseCase
   implements UseCase<CreateDownloadUrlCommand, CreateDownloadUrlResponse> {
-  metadata: S3Gateway;
+  logger: Logger;
+  storage: S3Gateway;
 
-  constructor({ s3Gateway }: CreateDownloadUrlDependencies) {
-    this.metadata = s3Gateway;
+  constructor({ logger, s3Gateway }: CreateDownloadUrlDependencies) {
+    this.logger = logger;
+    this.storage = s3Gateway;
   }
 
   async execute({
     filename,
     documentId
   }: CreateDownloadUrlCommand): Promise<CreateDownloadUrlResponse> {
-    return { downloadUrl: '' }; // todo!
+    this.logger.mergeContext({
+      filename,
+      documentId
+    }).log('creating temporary download url');
+
+    const downloadUrl = await this
+      .storage
+      .createDownloadUrl(`${documentId}/${filename}`, 300);
+
+    return { downloadUrl };
   }
 }

--- a/src/use-cases/CreateDownloadUrl.ts
+++ b/src/use-cases/CreateDownloadUrl.ts
@@ -1,0 +1,33 @@
+import { UseCase } from './UseCase';
+import { S3Gateway } from '../gateways';
+import { Logger } from '../logging';
+
+interface CreateDownloadUrlDependencies {
+  logger: Logger;
+  s3Gateway: S3Gateway;
+}
+
+interface CreateDownloadUrlCommand {
+  filename: string;
+  documentId: string;
+}
+
+interface CreateDownloadUrlResponse {
+  downloadUrl: string;
+}
+
+export default class CreateDownloadUrlUseCase
+  implements UseCase<CreateDownloadUrlCommand, CreateDownloadUrlResponse> {
+  metadata: S3Gateway;
+
+  constructor({ s3Gateway }: CreateDownloadUrlDependencies) {
+    this.metadata = s3Gateway;
+  }
+
+  async execute({
+    filename,
+    documentId
+  }: CreateDownloadUrlCommand): Promise<CreateDownloadUrlResponse> {
+    return { downloadUrl: '' }; // todo!
+  }
+}

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -3,3 +3,4 @@ export { default as IndexDocument } from './IndexDocument';
 export { default as GetMetadata } from './GetMetadata';
 export { default as SaveMetadata } from './SaveMetadata';
 export { default as FindDocuments } from './FindDocuments';
+export { default as CreateDownloadUrl } from './CreateDownloadUrl';


### PR DESCRIPTION
**What**  
Allows clients to download the contents of a document that has been previously uploaded, using the document id. This is achieved by generating a signed S3 URL for the object and then redirecting the client to it.

**Why**  
So that users are able to the view the documents that have been uploaded to the evidence store.

**Anything else?**
- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
