### PR TITLE
Correctly decodes S3 object keys

### DIFF
--- a/src/s3/objectCreated.test.ts
+++ b/src/s3/objectCreated.test.ts
@@ -43,4 +43,20 @@ describe('ObjectCreated handler', () => {
       })
     );
   });
+
+  it('decodes URI encoded keys', async () => {
+    await handler(
+      createS3Event('abcd12345/my+document+with+spaces.jpg'),
+      createMockContext(),
+      jest.fn()
+    );
+
+    expect(dependencies.indexDocument.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'abcd12345',
+        filename: 'my document with spaces.jpg',
+        objectKey: 'abcd12345/my document with spaces.jpg'
+      })
+    );
+  });
 });

--- a/src/s3/objectCreated.ts
+++ b/src/s3/objectCreated.ts
@@ -8,9 +8,10 @@ interface HandlerDependencies {
   indexDocument: IndexDocument;
 }
 
+const decodeURI = (s: string) => decodeURIComponent(s.replace(/\+/g, '%20'));
 const isMetadataFile = (key: string) => key.endsWith('.json');
 const getDocumentIdFromKey = (key: string) => key.split('/')[0];
-const getFilenameFromKey = (key: string) => key.split('/').reverse()[0];
+const getFilenameFromKey = (key: string) => decodeURI(key.split('/').reverse()[0]);
 
 const createHandler: (container: Container) => S3Handler = ({
   logger,
@@ -40,7 +41,7 @@ const createHandler: (container: Container) => S3Handler = ({
           await indexer.execute({
             documentId: getDocumentIdFromKey(key),
             filename: getFilenameFromKey(key),
-            objectKey: key
+            objectKey: decodeURI(key),
           });
           logger.log('successfully indexed');
         } catch (err) {


### PR DESCRIPTION
**What**  
When an S3 event is triggered by an object having been uploaded and the object key contains spaces they are URL encoded to "+". This is not removed by the S3 event and so when we make subsequent calls to S3 using the key provided in the event those calls will fail. This change correctly URL decodes the supplied object keys so that future calls can be made using them.

**Why**  
This fixes a bug where keys containing spaces were not indexed.

**Anything else?**
- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
