### PR TITLE
Adds document contents route to Fastify

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import { health, saveMetadata, getMetadata, findDocuments } from './routes';
+import { health, saveMetadata, getMetadata, findDocuments, getDocumentContents } from './routes';
 
 const app = fastify();
 
@@ -11,6 +11,7 @@ app.route(health);
 app.route(saveMetadata);
 app.route(getMetadata);
 app.route(findDocuments);
+app.route(getDocumentContents);
 
 if (require.main === module) {
   app.listen(5050, (err, address) => {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,3 +2,4 @@ export { default as health } from './health';
 export { default as saveMetadata } from './save-metadata';
 export { default as getMetadata } from './get-metadata';
 export { default as findDocuments } from './find-documents';
+export { default as getDocumentContents } from './get-document-contents';


### PR DESCRIPTION
**What**  
Adds document contents route to Fastify.

**Why**  
So that the route is exposed via the API.

**Anything else?**
- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
