### PR TITLE
Uses correct use-case for metadata in get contents

### DIFF
--- a/src/routes/get-document-contents.ts
+++ b/src/routes/get-document-contents.ts
@@ -1,20 +1,13 @@
 import dependencies from '../dependencies';
-import { FastifyRequest, RouteOptions, DefaultQuery } from 'fastify';
-import { IncomingMessage } from 'http';
-import { GetMetadata, CreateDownloadUrl } from '../use-cases';
+import { RouteOptions } from 'fastify';
+import { GetIndexedMetadata, CreateDownloadUrl } from '../use-cases';
 import { Logger } from '../logging';
 
 interface EndpointDependencies {
   logger: Logger;
-  getMetadata: GetMetadata;
+  getMetadata: GetIndexedMetadata;
   createDownloadUrl: CreateDownloadUrl;
 }
-
-interface Params {
-  documentId: string;
-}
-
-type Request = FastifyRequest<IncomingMessage, DefaultQuery, Params>;
 
 const createEndpoint = ({
   logger,
@@ -23,9 +16,9 @@ const createEndpoint = ({
 }: EndpointDependencies): RouteOptions => ({
   method: 'GET',
   url: '/:documentId/contents',
-  handler: async (req: Request, reply) => {
+  handler: async (req, reply) => {
     const { documentId, filename } = await getMetadata.execute({
-      documentId: req.params.documentId,
+      documentId: req.params['documentId'],
     });
 
     logger.mergeContext({ documentId, filename });
@@ -47,7 +40,7 @@ const createEndpoint = ({
 
 export default createEndpoint({
   logger: dependencies.logger,
-  getMetadata: dependencies.getMetadata,
+  getMetadata: dependencies.getIndexedMetadata,
   createDownloadUrl: dependencies.createDownloadUrl,
 });
 

--- a/src/routes/get-document-contents.ts
+++ b/src/routes/get-document-contents.ts
@@ -1,4 +1,3 @@
-import dependencies from '../dependencies';
 import { RouteOptions } from 'fastify';
 import { GetIndexedMetadata, CreateDownloadUrl } from '../use-cases';
 import { Logger } from '../logging';
@@ -36,12 +35,6 @@ const createEndpoint = ({
       reply.status(400).send();
     }
   },
-});
-
-export default createEndpoint({
-  logger: dependencies.logger,
-  getMetadata: dependencies.getIndexedMetadata,
-  createDownloadUrl: dependencies.createDownloadUrl,
 });
 
 export { createEndpoint };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,14 @@
+import dependencies from '../dependencies';
+import { createEndpoint as createGetDocumentContents } from './get-document-contents';
+
+const getDocumentContents = createGetDocumentContents({
+  logger: dependencies.logger,
+  createDownloadUrl: dependencies.createDownloadUrl,
+  getMetadata: dependencies.getIndexedMetadata,
+});
+
+export { getDocumentContents };
 export { default as health } from './health';
 export { default as saveMetadata } from './save-metadata';
 export { default as getMetadata } from './get-metadata';
 export { default as findDocuments } from './find-documents';
-export { default as getDocumentContents } from './get-document-contents';


### PR DESCRIPTION
**What**  
Uses the correct use-case when fetching metadata for the get contents endpoint, as a result of a previous merge the GetMetadata use case deals with retrieving all metadata from an object (including metadata stored directly on the S3 object). The GetIndexedMetadata use case will fetch the indexed metadata from Elasticsearch and is more suited to this endpoints requirements (it doesn't require the S3 object key to be available).

**Why**  
So that we can retrieve necessary object details to produce a signed download URL.

**Anything else?**

- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? Nope.
- Anything else in this PR that isn't covered by the what/why? Nada.
