### PR TITLE
Supports optional redirect to document contents

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -45,6 +45,14 @@ paths:
         Gets the contents of a document from S3 using the document id
       parameters:
         - $ref: "#/components/parameters/documentId"
+        - name: redirect
+          in: query
+          required: false
+          description: >
+            Whether or not to redirect to the secure download URL or not,
+            defaults to true. If set to false, returns a 200 instead.
+          schema:
+            type: boolean
       responses:
         302:
           description: Found
@@ -53,6 +61,17 @@ paths:
               schema:
                 type: string
               description: The location of the document contents
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  downloadUrl:
+                    type: string
+                    description: The secure temporary download URL for the contents
+                    example: "https://very.secure.url/?token=temporary.one.time.token"
   /search:
     post:
       operationId: find-documents

--- a/src/routes/get-document-contents.test.ts
+++ b/src/routes/get-document-contents.test.ts
@@ -41,4 +41,17 @@ describe('GET /{documentId}/contents', () => {
       expectedDownloadRepsonse.downloadUrl
     );
   });
+
+  it('returns the expected download URL if redirect is not requested', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/ahw82u/contents',
+      query: { redirect: 'false' }
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toStrictEqual(
+      JSON.stringify(expectedDownloadRepsonse)
+    );
+  });
 });


### PR DESCRIPTION
**What**  
Adds an additional query parameter to the document contents endpoint that will allow the secure download URL to be retrieved and presented in the response body, rather than as a redirect to the content.

**Why**  
This allows applications to "proxy" requests where authentication is not supported by their end users, retrieve the secure download URL and then present it to their users - rather than relying on redirection.

**Anything else?**

- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? Nope.
- Anything else in this PR that isn't covered by the what/why? Nada.
