### PR TITLE
Support deleting documents and their content

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: integration-tests
           command: |
-            export INTEGRATION_TEST_BASE_URL=$(echo $(npx serverless info -s test | grep -o -m 1 "https://.*/test/"))
+            export INTEGRATION_TEST_BASE_URL=$(echo $(npx serverless info -s test | grep -o -m 1 "https://.*/test"))
             npm run test:integration
 
   deploy:

--- a/docs/api.yml
+++ b/docs/api.yml
@@ -38,6 +38,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/metadata"
+    delete:
+      operationId: delete-document
+      summary: Deletes a document and associated metadata using the id
+      parameters:
+        - $ref: "#/components/parameters/documentId"
+      responses:
+        204:
+          description: OK
   /{documentId}/contents:
     get:
       operationId: get-document-contents

--- a/integration/client/EvidenceStoreClient.ts
+++ b/integration/client/EvidenceStoreClient.ts
@@ -37,14 +37,24 @@ class EvidenceStoreClient {
       body: body ?? '<<not set>>',
     }, undefined, 2));
 
+    const buildRequestHeaders = () => {
+      const headers = {
+        accept: 'application/json',
+        'authorization': `Bearer ${this.authorizationToken}`
+      };
+
+      if (body) {
+        // Content-Type must _not_ be set without a body.
+        headers['content-type'] = 'application/json';
+      }
+
+      return headers;
+    }
+
     const response = await fetch(requestUrl, {
       method,
       body: JSON.stringify(body),
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-        'authorization': `Bearer ${this.authorizationToken}`
-      },
+      headers: buildRequestHeaders(),
     });
 
     let responseBody = null;

--- a/integration/client/EvidenceStoreClient.ts
+++ b/integration/client/EvidenceStoreClient.ts
@@ -76,6 +76,10 @@ class EvidenceStoreClient {
   getMetadata(documentId: string): Promise<Response> {
     return this.request({ method: 'GET', path: `/${documentId}` });
   }
+
+  deleteByDocumentId(documentId: string): Promise<Response> {
+    return this.request({ method: 'DELETE', path: `/${documentId}` });
+  }
 }
 
 export default EvidenceStoreClient;

--- a/integration/routes/delete.test.ts
+++ b/integration/routes/delete.test.ts
@@ -1,0 +1,8 @@
+import client from '../client';
+
+describe('POST /{documentId}', () => {
+  it('responds with a 204', async () => {
+    const { statusCode } = await client.deleteByDocumentId('j72hkk');
+    expect(statusCode).toBe(204);
+  });
+});

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -10,6 +10,7 @@ import {
   FindDocuments,
   CreateDownloadUrl,
   GetIndexedMetadata,
+  DeleteDocument,
 } from './use-cases';
 import { createAWSConnection, awsCredsifyAll } from '@acuris/aws-es-connection';
 
@@ -103,6 +104,14 @@ class DefaultContainer implements Container {
     return new CreateDownloadUrl({
       logger: this.logger,
       s3Gateway: this.s3Gateway,
+    });
+  }
+
+  get deleteDocument() {
+    return new DeleteDocument({
+      logger: this.logger,
+      s3Gateway: this.s3Gateway,
+      elasticsearchGateway: this.elasticsearchGateway,
     });
   }
 }

--- a/src/gateways/ElasticsearchGateway.test.ts
+++ b/src/gateways/ElasticsearchGateway.test.ts
@@ -114,10 +114,12 @@ describe('ElasticsearchGateway', () => {
     it('deletes from the Elasticsearch index', async () => {
       await gateway.deleteByDocumentId(metadata.documentId);
 
-      expect(client.delete).toHaveBeenCalledWith({
-        index: indexName,
-        id: metadata.documentId,
-      });
+      expect(client.delete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: indexName,
+          id: metadata.documentId,
+        })
+      );
     });
 
     describe('when there is an error', () => {

--- a/src/gateways/ElasticsearchGateway.test.ts
+++ b/src/gateways/ElasticsearchGateway.test.ts
@@ -41,6 +41,11 @@ describe('ElasticsearchGateway', () => {
           },
         })
       ),
+      delete: jest.fn(() => Promise.resolve({
+        body: {
+          result: "deleted"
+        }
+      })),
       search: jest.fn(() => Promise.resolve(elasticSearchResponse)),
       cat: {
         indices: jest.fn((index, callback) => {
@@ -101,6 +106,31 @@ describe('ElasticsearchGateway', () => {
         });
 
         await expect(gateway.index(metadata)).rejects.toThrow(error);
+      });
+    });
+  });
+
+  describe('#deleteByDocumentId', () => {
+    it('deletes from the Elasticsearch index', async () => {
+      await gateway.deleteByDocumentId(metadata.documentId);
+
+      expect(client.delete).toHaveBeenCalledWith({
+        index: indexName,
+        id: metadata.documentId,
+      });
+    });
+
+    describe('when there is an error', () => {
+      const error = new Error('Failed to delete');
+
+      it('bubbles up errors', async () => {
+        (client.delete as jest.Mock).mockImplementation(() => {
+          throw error;
+        });
+
+        await expect(
+          gateway.deleteByDocumentId(metadata.documentId)
+        ).rejects.toThrow(error);
       });
     });
   });

--- a/src/gateways/ElasticsearchGateway.ts
+++ b/src/gateways/ElasticsearchGateway.ts
@@ -82,6 +82,24 @@ export class ElasticsearchGateway {
     return metadata.body._source;
   }
 
+  async deleteByDocumentId(documentId: string): Promise<void> {
+    this.logger
+      .mergeContext({
+        indexName: this.indexName,
+        documentId,
+      })
+      .log('[elasticsearch] deleting document metadata');
+
+    const response = await this.client.delete({
+      id: documentId,
+      index: this.indexName,
+    });
+
+    this.logger
+      .mergeContext({ esDeleteResponse: response })
+      .log('[elasticsearch] delete completed');
+  }
+
   async findDocuments({
     metadata,
   }: FindDocumentMetadata): Promise<ElasticsearchDocumentMetadata[]> {

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -88,7 +88,7 @@ export class S3Gateway {
     this.logger
       .mergeContext({
         bucketPrefix: listing.Prefix,
-        matchesFoundInBucket: listing.Contents?.length,
+        matchesFoundInBucket: (listing.Contents || []).length,
       }).log('[s3] found objects in bucket with prefix');
 
     const keys = listing.Contents.map(object => object.Key);

--- a/src/gateways/S3Gateway.ts
+++ b/src/gateways/S3Gateway.ts
@@ -74,6 +74,37 @@ export class S3Gateway {
     return JSON.parse(object.Body.toString());
   }
 
+  async deleteByDocumentId(documentId: string): Promise<void> {
+    this.logger
+      .mergeContext({ documentId })
+      .log('[s3] removing all objects associated with id');
+
+    const listing = await this.client.listObjects({
+      Bucket: this.bucketName,
+      Prefix: `${documentId}/`,
+      MaxKeys: 2, // safeguard against bad prefixes
+    }).promise();
+
+    this.logger
+      .mergeContext({
+        bucketPrefix: listing.Prefix,
+        matchesFoundInBucket: listing.Contents?.length,
+      }).log('[s3] found objects in bucket with prefix');
+
+    const keys = listing.Contents.map(object => object.Key);
+
+    if (keys.length > 0) {
+      await this.client.deleteObjects({
+        Bucket: this.bucketName,
+        Delete: {
+          Objects: keys.map(key => ({ Key: key }))
+        }
+      }).promise();
+    }
+
+    this.logger.log('[s3] deleted objects in bucket');
+  }
+
   async createDownloadUrl(key: string, expiresIn: number): Promise<string> {
     this.logger
       .mergeContext({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import fastify from 'fastify';
-import { health, saveMetadata, getMetadata, findDocuments, getDocumentContents } from './routes';
+import {
+  deleteDocument,
+  findDocuments,
+  getDocumentContents,
+  getMetadata,
+  health,
+  saveMetadata,
+} from './routes';
 
 const app = fastify();
 
@@ -12,6 +19,7 @@ app.route(saveMetadata);
 app.route(getMetadata);
 app.route(findDocuments);
 app.route(getDocumentContents);
+app.route(deleteDocument);
 
 if (require.main === module) {
   app.listen(5050, (err, address) => {

--- a/src/routes/delete-document.test.ts
+++ b/src/routes/delete-document.test.ts
@@ -1,0 +1,25 @@
+import fastify from 'fastify';
+import { DeleteDocument } from '../use-cases';
+import { createEndpoint } from './delete-document';
+import { NoOpLogger } from '../logging/NoOpLogger';
+
+describe('DELETE /{documentId}', () => {
+  const deleteDocument = ({
+    execute: jest.fn(() => Promise.resolve()),
+  } as unknown) as DeleteDocument;
+
+  const app = fastify();
+  app.route(createEndpoint({ deleteDocument, logger: new NoOpLogger() }));
+
+  it('calls delete and returns a 204', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/ahw82u',
+    });
+
+    expect(deleteDocument.execute)
+      .toHaveBeenCalledWith({ documentId: 'ahw82u' });
+
+    expect(response.statusCode).toBe(204);
+  });
+});

--- a/src/routes/delete-document.ts
+++ b/src/routes/delete-document.ts
@@ -1,0 +1,31 @@
+import { RouteOptions } from 'fastify';
+import { DeleteDocument } from '../use-cases';
+import { Logger } from '../logging';
+
+interface EndpointDependencies {
+  logger: Logger;
+  deleteDocument: DeleteDocument;
+}
+
+const createEndpoint = ({
+  logger,
+  deleteDocument
+}: EndpointDependencies): RouteOptions => ({
+  method: 'DELETE',
+  url: '/:documentId',
+  handler: async (req, reply) => {
+    const documentId = req.params['documentId'];
+    logger.mergeContext({ documentId });
+
+    try {
+      await deleteDocument.execute({ documentId });
+      logger.log('successfully deleted');
+      reply.status(204).send();
+    } catch (err) {
+      logger.error(err).log('failed to delete');
+      throw err;
+    }
+  },
+});
+
+export { createEndpoint };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import dependencies from '../dependencies';
 import { createEndpoint as createGetDocumentContents } from './get-document-contents';
+import { createEndpoint as createDeleteDocument } from './delete-document';
 
 const getDocumentContents = createGetDocumentContents({
   logger: dependencies.logger,
@@ -7,6 +8,12 @@ const getDocumentContents = createGetDocumentContents({
   getMetadata: dependencies.getIndexedMetadata,
 });
 
+const deleteDocument = createDeleteDocument({
+  logger: dependencies.logger,
+  deleteDocument: dependencies.deleteDocument,
+});
+
+export { deleteDocument };
 export { getDocumentContents };
 export { default as health } from './health';
 export { default as saveMetadata } from './save-metadata';

--- a/src/use-cases/DeleteDocument.test.ts
+++ b/src/use-cases/DeleteDocument.test.ts
@@ -1,0 +1,56 @@
+import { DeleteDocument } from '.';
+import { ElasticsearchGateway, S3Gateway } from '../gateways';
+import { NoOpLogger } from '../logging/NoOpLogger';
+
+describe('DeleteDocument', () => {
+  const expectedMetadata = {
+    documentId: 'tewg61a',
+    some: 'key',
+    another: 'value',
+    filename: 'cat.jpg',
+  };
+
+  let usecase: DeleteDocument;
+  let es: ElasticsearchGateway;
+  let s3: S3Gateway;
+
+  beforeEach(() => {
+    es = ({
+      deleteByDocumentId: jest.fn(() => Promise.resolve())
+    } as unknown) as ElasticsearchGateway;
+
+    s3 = ({
+      deleteByDocumentId: jest.fn(() => Promise.resolve())
+    } as unknown) as S3Gateway;
+
+    usecase = new DeleteDocument({
+      logger: new NoOpLogger(),
+      s3Gateway: s3,
+      elasticsearchGateway: es,
+    });
+  });
+
+  describe('when called with a valid documentId', () => {
+    it('deletes the document from S3 and Elasticsearch', async () => {
+      await usecase.execute({ documentId: 'tewg61a' });
+      expect(es.deleteByDocumentId).toHaveBeenLastCalledWith('tewg61a');
+      expect(s3.deleteByDocumentId).toHaveBeenLastCalledWith('tewg61a');
+    });
+  });
+
+  describe('when deleting fails', () => {
+    const error = new Error('Failed to delete');
+
+    beforeEach(() => {
+      (es.deleteByDocumentId as jest.Mock).mockImplementation(() => {
+        throw error;
+      });
+    });
+
+    it('throws bubbles up the error', async () => {
+      await expect(
+        usecase.execute({ documentId: 'UNKNOWN' })
+      ).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/use-cases/DeleteDocument.ts
+++ b/src/use-cases/DeleteDocument.ts
@@ -1,0 +1,46 @@
+import { UseCase } from './UseCase';
+import { ElasticsearchGateway, S3Gateway } from '../gateways';
+import { Logger } from '../logging';
+
+interface DeleteDocumentDependencies {
+  logger: Logger;
+  s3Gateway: S3Gateway;
+  elasticsearchGateway: ElasticsearchGateway;
+}
+
+interface DeleteDocumentCommand {
+  documentId: string;
+}
+
+export default class DeleteDocumentUseCase
+  implements UseCase<DeleteDocumentCommand, void> {
+  logger: Logger;
+  contents: S3Gateway;
+  es: ElasticsearchGateway;
+
+  constructor({
+    logger,
+    s3Gateway,
+    elasticsearchGateway,
+  }: DeleteDocumentDependencies) {
+    this.logger = logger;
+    this.contents = s3Gateway;
+    this.es = elasticsearchGateway;
+  }
+
+  async execute({ documentId }: DeleteDocumentCommand): Promise<void> {
+    this.logger.mergeContext({ documentId }).log('deleting document');
+
+    try {
+      await Promise.all([
+        this.es.deleteByDocumentId(documentId),
+        this.contents.deleteByDocumentId(documentId),
+      ]);
+
+      this.logger.log('delete successful');
+    } catch (err) {
+      this.logger.error(err).log('deleting document failed');
+      throw err;
+    }
+  }
+}

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -5,3 +5,4 @@ export { default as SaveMetadata } from './SaveMetadata';
 export { default as FindDocuments } from './FindDocuments';
 export { default as CreateDownloadUrl } from './CreateDownloadUrl';
 export { default as GetIndexedMetadata } from './GetIndexedMetadata';
+export { default as DeleteDocument } from './DeleteDocument';


### PR DESCRIPTION
**What**  
Adds support for deleting documents from the store, along with their metadata.

**Why**  
So that users can remove files they have uploaded when they are no longer required.

**Anything else?**
- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
