### PR TITLE
Index metadata

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -60,6 +60,7 @@ class DefaultContainer implements Container {
     return new SaveMetadata({
       s3Gateway: this.s3Gateway,
       createDocumentId: () => nanoid(6),
+      esGateway: this.elasticsearchGateway,
     });
   }
 

--- a/src/use-cases/SaveMetadata.test.ts
+++ b/src/use-cases/SaveMetadata.test.ts
@@ -1,5 +1,6 @@
 import SaveMetadata from './SaveMetadata';
 import { S3Gateway } from '../gateways';
+import { ElasticsearchGateway } from '../gateways';
 
 describe('Save Metadata Use Case', () => {
   const usecase = new SaveMetadata({
@@ -15,14 +16,17 @@ describe('Save Metadata Use Case', () => {
       ),
     } as unknown) as S3Gateway,
     createDocumentId: jest.fn(() => '123'),
+    esGateway: ({
+      index: jest.fn(),
+    } as unknown) as ElasticsearchGateway,
   });
 
-  it('Saves metadata to S3', async () => {
-    const metadata = {
-      firstName: 'Aidan',
-      dob: '1999-09-09',
-    };
+  const metadata = {
+    firstName: 'Aidan',
+    dob: '1999-09-09',
+  };
 
+  it('Saves metadata to S3', async () => {
     await usecase.execute({ metadata });
 
     expect(usecase.s3Gateway.create).toHaveBeenCalledWith(
@@ -35,12 +39,19 @@ describe('Save Metadata Use Case', () => {
   });
 
   it('creates an upload url', async () => {
-    const metadata = {
-      firstName: 'Aidan',
-      dob: '1999-09-09',
-    };
-
     await usecase.execute({ metadata });
     expect(usecase.s3Gateway.createUrl).toHaveBeenCalledWith('123');
+  });
+
+  it('indexes metadata files', async () => {
+    await usecase.execute({ metadata });
+
+    expect(usecase.esGateway.index).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dob: '1999-09-09',
+        documentId: '123',
+        firstName: 'Aidan',
+      })
+    );
   });
 });

--- a/src/use-cases/SaveMetadata.test.ts
+++ b/src/use-cases/SaveMetadata.test.ts
@@ -5,7 +5,9 @@ import { ElasticsearchGateway } from '../gateways';
 describe('Save Metadata Use Case', () => {
   const usecase = new SaveMetadata({
     s3Gateway: ({
-      create: jest.fn(() => Promise.resolve({ documentId: '123' })),
+      create: jest.fn((metadata) =>
+        Promise.resolve({ ...metadata, documentId: '123' })
+      ),
       createUrl: jest.fn(() =>
         Promise.resolve({
           url: 'https://s3.eu-west-2.amazonaws.com/bucketName',

--- a/src/use-cases/SaveMetadata.ts
+++ b/src/use-cases/SaveMetadata.ts
@@ -39,15 +39,12 @@ export default class SaveMetadataUseCase
   async execute({
     metadata,
   }: SaveMetadataCommand): Promise<SaveMetadataResult> {
-    const documentId = this.createDocumentId();
-
     const created = await this.s3Gateway.create({
-      documentId,
+      documentId: this.createDocumentId(),
       ...metadata,
     });
 
-    const indexMetadata = Object.assign({}, metadata, { documentId });
-    await this.esGateway.index(indexMetadata as DocumentMetadata);
+    await this.esGateway.index(created);
 
     const { url, fields } = await this.s3Gateway.createUrl(created.documentId);
 


### PR DESCRIPTION
**What**  
Index metadata as soon as the dropbox is created. 
Keep the rest of the indexing the same. This means that the object will get reindexed when an actual document gets uploaded to s3. Description from _X-Amz-Meta-Description_ and filename from the key (<docId>/**<filename>**)

**Why**  
To make drop boxes searchable even if no documents are in it.

**Anything else?**
- Have you added any new third-party libraries? no
- Are any new environment variables or configuration values needed? no
- Anything else in this PR that isn't covered by the what/why? no
