### PR TITLE
Add GetPresignedUploadUrl use case and route

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -1,4 +1,4 @@
-openapi: "3.0.0"
+openapi: '3.0.0'
 info:
   title: Evidence Store API
   version: 1.0.0
@@ -6,7 +6,7 @@ paths:
   /metadata:
     post:
       operationId: save-metadata
-      summary: Saves metadata to S3 bucket
+      summary: Saves metadata to a S3 bucket and returns a pre-signed POST url
       requestBody:
         content:
           application/json:
@@ -18,31 +18,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/metadata"
+                $ref: '#/components/schemas/metadata'
               example:
                 {
-                  "documentId": "kjsak2",
-                  "firstName": "The name",
-                  "dob": "1999-01-01",
+                  'documentId': 'abc123',
+                  'url': 'https://s3.eu-west-2.amazonaws.com/bucket/abc123',
+                  'fields': { 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256' },
                 }
   /{documentId}:
     get:
       operationId: get-metadata
       summary: Gets a document from S3 using the document id
       parameters:
-        - $ref: "#/components/parameters/documentId"
+        - $ref: '#/components/parameters/documentId'
       responses:
         200:
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/metadata"
+                $ref: '#/components/schemas/metadata'
     delete:
       operationId: delete-document
       summary: Deletes a document and associated metadata using the id
       parameters:
-        - $ref: "#/components/parameters/documentId"
+        - $ref: '#/components/parameters/documentId'
       responses:
         204:
           description: OK
@@ -52,7 +52,7 @@ paths:
       summary: >
         Gets the contents of a document from S3 using the document id
       parameters:
-        - $ref: "#/components/parameters/documentId"
+        - $ref: '#/components/parameters/documentId'
         - name: redirect
           in: query
           required: false
@@ -79,7 +79,26 @@ paths:
                   downloadUrl:
                     type: string
                     description: The secure temporary download URL for the contents
-                    example: "https://very.secure.url/?token=temporary.one.time.token"
+                    example: 'https://very.secure.url/?token=temporary.one.time.token'
+  /{documentId}/upload-url:
+    get:
+      operationId: get-upload-url
+      summary: Gets the presigned POST url of an existing document folder
+      parameters:
+        - $ref: '#/components/parameters/documentId'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/metadata'
+              example:
+                {
+                  'documentId': 'abc123',
+                  'url': 'https://s3.eu-west-2.amazonaws.com/bucket/abc123',
+                  'fields': { 'X-Amz-Algorithm': 'AWS4-HMAC-SHA256' },
+                }
   /search:
     post:
       operationId: find-documents
@@ -89,7 +108,7 @@ paths:
           application/json:
             schema:
               type: object
-              example: { "firstName": "Toaster", "dob": "1999-01-01" }
+              example: { 'firstName': 'Toaster', 'dob': '1999-01-01' }
       responses:
         200:
           description: Documents
@@ -97,21 +116,21 @@ paths:
             application/json:
               example:
                 {
-                  "documents":
+                  'documents':
                     [
                       {
-                        "documentId": "1",
-                        "index": "documents",
-                        "score": 0.3,
-                        "metadata":
-                          { "firstName": "Toaster", "dob": "1999-01-01" },
+                        'documentId': '1',
+                        'index': 'documents',
+                        'score': 0.3,
+                        'metadata':
+                          { 'firstName': 'Toaster', 'dob': '1999-01-01' },
                       },
                       {
-                        "documentId": "2",
-                        "index": "documents",
-                        "score": 0.5,
-                        "metadata":
-                          { "firstName": "Toaster", "dob": "1999-01-01" },
+                        'documentId': '2',
+                        'index': 'documents',
+                        'score': 0.5,
+                        'metadata':
+                          { 'firstName': 'Toaster', 'dob': '1999-01-01' },
                       },
                     ],
                 }

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -11,6 +11,7 @@ import {
   CreateDownloadUrl,
   GetIndexedMetadata,
   DeleteDocument,
+  GetPresignedUploadUrl,
 } from './use-cases';
 import { createAWSConnection, awsCredsifyAll } from '@acuris/aws-es-connection';
 
@@ -113,6 +114,12 @@ class DefaultContainer implements Container {
       logger: this.logger,
       s3Gateway: this.s3Gateway,
       elasticsearchGateway: this.elasticsearchGateway,
+    });
+  }
+
+  get getPresignedUploadUrl() {
+    return new GetPresignedUploadUrl({
+      s3Gateway: this.s3Gateway,
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   getMetadata,
   health,
   saveMetadata,
+  getPresignedUploadUrl,
 } from './routes';
 
 const app = fastify();
@@ -20,6 +21,7 @@ app.route(getMetadata);
 app.route(findDocuments);
 app.route(getDocumentContents);
 app.route(deleteDocument);
+app.route(getPresignedUploadUrl);
 
 if (require.main === module) {
   app.listen(5050, (err, address) => {

--- a/src/routes/get-presigned-upload-url.test.ts
+++ b/src/routes/get-presigned-upload-url.test.ts
@@ -1,0 +1,30 @@
+jest.mock('../dependencies');
+import fastify from 'fastify';
+import { createEndpoint } from './get-presigned-upload-url';
+import { GetPresignedUploadUrl } from '../use-cases';
+
+describe('GET /:documentId/upload-url', () => {
+  const expectedResponse = {
+    documentId: '123',
+    url: 'https://s3.eu-west-2.amazonaws.com/bucketName',
+    fields: {
+      'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+    },
+  };
+
+  const getPresignedUploadUrl = ({
+    execute: jest.fn(() => expectedResponse),
+  } as unknown) as GetPresignedUploadUrl;
+
+  const app = fastify();
+  app.route(createEndpoint({ getPresignedUploadUrl }));
+
+  it('can get a url', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/123/upload-url',
+    });
+    expect(response.body).toStrictEqual(JSON.stringify(expectedResponse));
+    expect(response.statusCode).toBe(200);
+  });
+});

--- a/src/routes/get-presigned-upload-url.ts
+++ b/src/routes/get-presigned-upload-url.ts
@@ -1,0 +1,26 @@
+import dependencies from '../dependencies';
+import { RouteOptions } from 'fastify';
+import { GetPresignedUploadUrl } from '../use-cases';
+
+interface EndpointDependencies {
+  getPresignedUploadUrl: GetPresignedUploadUrl;
+}
+
+const createEndpoint = ({
+  getPresignedUploadUrl,
+}: EndpointDependencies): RouteOptions => ({
+  method: 'GET',
+  url: '/:documentId/upload-url',
+  handler: async (req, reply) => {
+    const result = await getPresignedUploadUrl.execute({
+      documentId: req.params['documentId'],
+    });
+    reply.status(200).send(result);
+  },
+});
+
+export default createEndpoint({
+  getPresignedUploadUrl: dependencies.getPresignedUploadUrl,
+});
+
+export { createEndpoint };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -19,3 +19,4 @@ export { default as health } from './health';
 export { default as saveMetadata } from './save-metadata';
 export { default as getMetadata } from './get-metadata';
 export { default as findDocuments } from './find-documents';
+export { default as getPresignedUploadUrl } from './get-presigned-upload-url';

--- a/src/use-cases/GetPresignedUploadUrl.test.ts
+++ b/src/use-cases/GetPresignedUploadUrl.test.ts
@@ -1,0 +1,24 @@
+import GetPresignedUploadUrl from './GetPresignedUploadUrl';
+import { S3Gateway } from '../gateways';
+
+describe('Get Presigned Upload Url Use Case', () => {
+  const usecase = new GetPresignedUploadUrl({
+    s3Gateway: ({
+      createUrl: jest.fn(() =>
+        Promise.resolve({
+          url: 'https://s3.eu-west-2.amazonaws.com/bucketName',
+          fields: {
+            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+          },
+        })
+      ),
+    } as unknown) as S3Gateway,
+  });
+
+  it('gets a presigned upload url from S3', async () => {
+    const documentId = '123';
+    await usecase.execute({ documentId });
+
+    expect(usecase.s3Gateway.createUrl).toHaveBeenCalledWith(documentId);
+  });
+});

--- a/src/use-cases/GetPresignedUploadUrl.ts
+++ b/src/use-cases/GetPresignedUploadUrl.ts
@@ -1,0 +1,38 @@
+import { S3Gateway } from '../gateways';
+import { UseCase } from './UseCase';
+
+interface GetPresignedUploadUrlDependencies {
+  s3Gateway: S3Gateway;
+}
+
+interface GetPresignedUploadUrlResult {
+  documentId: string;
+  url: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fields: { [key: string]: any };
+}
+
+interface GetPresignedUploadUrlParams {
+  documentId: string;
+}
+
+export default class GetPresignedUploadUrlUseCase
+  implements UseCase<GetPresignedUploadUrlParams, GetPresignedUploadUrlResult> {
+  s3Gateway: S3Gateway;
+
+  constructor({ s3Gateway }: GetPresignedUploadUrlDependencies) {
+    this.s3Gateway = s3Gateway;
+  }
+
+  async execute({
+    documentId,
+  }: GetPresignedUploadUrlParams): Promise<GetPresignedUploadUrlResult> {
+    const { url, fields } = await this.s3Gateway.createUrl(documentId);
+
+    return {
+      documentId,
+      url,
+      fields,
+    };
+  }
+}

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -6,3 +6,4 @@ export { default as FindDocuments } from './FindDocuments';
 export { default as CreateDownloadUrl } from './CreateDownloadUrl';
 export { default as GetIndexedMetadata } from './GetIndexedMetadata';
 export { default as DeleteDocument } from './DeleteDocument';
+export { default as GetPresignedUploadUrl } from './GetPresignedUploadUrl';


### PR DESCRIPTION
**What**  
Adds a GetPresignedUploadUrl use case and route. Route is at ```/:documentId/upload-url```

**Why**  
So we can upload to an existing document folder if it doesn't have a document stored, instead of creating a new folder every time.

