### PR TITLE
Increases the number of items returned by search

### DIFF
--- a/src/gateways/ElasticsearchGateway.test.ts
+++ b/src/gateways/ElasticsearchGateway.test.ts
@@ -143,6 +143,7 @@ describe('ElasticsearchGateway', () => {
 
       const expectedRequest = {
         index: indexName,
+        size: 100,
         body: {
           query: {
             bool: {

--- a/src/gateways/ElasticsearchGateway.ts
+++ b/src/gateways/ElasticsearchGateway.ts
@@ -130,6 +130,7 @@ export class ElasticsearchGateway {
 
     const response = await this.client.search({
       index: this.indexName,
+      size: 100,
       body: {
         query,
       },


### PR DESCRIPTION
**What**  
Increases the number of items returned by search, from 10 to 100.

**Why**  
Listing documents in the customer document uploads tool calls Evidence Store to retrieve a listing of all files in a dropbox, if more than 10 files are uploaded to a single dropbox there will be some files missing at present.

A more flexible approach would be to support paging and make this configurable by the calling client. This is something to explore in the future.

**Anything else?**

- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
