### PR TITLE
Indexes the upload date and time for objects

### DIFF
--- a/src/s3/objectCreated.ts
+++ b/src/s3/objectCreated.ts
@@ -42,6 +42,7 @@ const createHandler: (container: Container) => S3Handler = ({
             documentId: getDocumentIdFromKey(key),
             filename: getFilenameFromKey(key),
             objectKey: decodeURI(key),
+            uploadedDate: new Date(Date.now()),
           });
           logger.log('successfully indexed');
         } catch (err) {

--- a/src/use-cases/IndexDocument.test.ts
+++ b/src/use-cases/IndexDocument.test.ts
@@ -4,11 +4,14 @@ import { ElasticsearchGateway } from '../gateways';
 import { NoOpLogger } from '../logging/NoOpLogger';
 
 describe('IndexDocument', () => {
+  const expectedDate = new Date(1597744712808);
+
   const expectedMetadata = {
     documentId: 'tewg61a',
     some: 'key',
     another: 'value',
     filename: 'cat.jpg',
+    uploadedDate: expectedDate.toISOString(),
   };
 
   let usecase: IndexDocument;
@@ -33,6 +36,7 @@ describe('IndexDocument', () => {
         documentId: 'tewg61a',
         filename: 'passport.jpg',
         objectKey: 'tewg61a/passport.jpg',
+        uploadedDate: expectedDate,
       });
 
       expect(getMetadata.execute).toHaveBeenLastCalledWith({
@@ -46,6 +50,7 @@ describe('IndexDocument', () => {
         documentId: 'tewg61a',
         filename: 'cat.jpg',
         objectKey: 'tewg61a/cat.jpg',
+        uploadedDate: expectedDate,
       });
 
       expect(es.index).toHaveBeenCalledWith(expectedMetadata);
@@ -65,6 +70,7 @@ describe('IndexDocument', () => {
           documentId: 'UNKNOWN',
           filename: 'passport.jpg',
           objectKey: 'tewg61a/passport.jpg',
+          uploadedDate: expectedDate,
         })
       ).rejects.toThrow(UnknownDocumentError);
     });

--- a/src/use-cases/IndexDocument.ts
+++ b/src/use-cases/IndexDocument.ts
@@ -14,6 +14,7 @@ interface IndexDocumentCommand {
   documentId: string;
   filename: string;
   objectKey: string;
+  uploadedDate: Date;
 }
 
 export default class IndexDocumentUseCase
@@ -36,9 +37,10 @@ export default class IndexDocumentUseCase
     documentId,
     filename,
     objectKey,
+    uploadedDate,
   }: IndexDocumentCommand): Promise<void> {
     this.logger
-      .mergeContext({ documentId, filename, objectKey })
+      .mergeContext({ documentId, filename, objectKey, uploadedDate })
       .log('indexing document');
 
     try {
@@ -47,7 +49,11 @@ export default class IndexDocumentUseCase
         objectKey,
       });
 
-      await this.es.index({ ...metadata, filename });
+      await this.es.index({
+        ...metadata,
+        filename,
+        uploadedDate: uploadedDate.toISOString()
+      });
     } catch (err) {
       this.logger.error(err).log('indexing failed');
       throw new UnknownDocumentError(documentId);


### PR DESCRIPTION
**What**  
Indexes the date and time at which objects are uploaded to the S3 bucket (arguably this is actually the time when they were indexed, but the delay between upload and indexing should be negligible for any of our use cases). This value is stored as an ISO-8601 datetime in the `uploadedDate` field.

**Why**  
So that client applications (initially Single View) can show a list of documents in chronological order. This also helps with auditing and identifying how long documents have been held for.

**Anything else?**

- Have you added any new third-party libraries? No.
- Are any new environment variables or configuration values needed? No.
- Anything else in this PR that isn't covered by the what/why? No.
