### PR TITLE
Update search query and add minimum match terms

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -108,7 +108,21 @@ paths:
           application/json:
             schema:
               type: object
-              example: { 'firstName': 'Toaster', 'dob': '1999-01-01' }
+              properties:
+                metadata:
+                  type: object
+                  description: metadata key/values to search
+                  required: true
+                minimumMatchTerms:
+                  type: integer
+                  description: minimum number of metadata values to match
+                  required: false
+                  default: 1
+              example:
+                {
+                  metadata: { 'firstName': 'Toaster', 'dob': '1999-01-01' },
+                  minimumMatchTerms: 2,
+                }
       responses:
         200:
           description: Documents

--- a/src/routes/find-documents.test.ts
+++ b/src/routes/find-documents.test.ts
@@ -28,8 +28,11 @@ describe('POST /search', () => {
       method: 'POST',
       url: '/search',
       payload: {
-        firstName: 'Tim',
-        lastName: 'Rose',
+        metadata: {
+          firstName: 'Tim',
+          lastName: 'Rose',
+        },
+        minimumMatchTerms: 1,
       },
     });
     expect(response.body).toStrictEqual(JSON.stringify(expectedResponse));
@@ -50,10 +53,7 @@ describe('POST /search', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/search',
-      payload: {
-        firstName: 5,
-        lastName: 'Rose',
-      },
+      payload: { metadata: { firstName: 5, lastName: 'Rose' } },
     });
 
     expect(response.statusCode).toBe(400);
@@ -67,7 +67,7 @@ describe('POST /search', () => {
       method: 'POST',
       url: '/search',
       payload: {
-        lastName: ['Rose', 'Blue', { sneaky: 'object' }],
+        metadata: { lastName: ['Rose', 'Blue', { sneaky: 'object' }] },
       },
     });
 

--- a/src/routes/find-documents.ts
+++ b/src/routes/find-documents.ts
@@ -19,7 +19,7 @@ const createEndpoint = ({
   method: 'POST',
   url: '/search',
   handler: async (req, reply) => {
-    const metadata = req.body;
+    const metadata = req.body['metadata'];
 
     for (const value of Object.values(metadata)) {
       if (!isStringOrArray(value)) {
@@ -31,7 +31,10 @@ const createEndpoint = ({
       }
     }
 
-    const result = await findDocuments.execute({ metadata: req.body });
+    const result = await findDocuments.execute({
+      metadata,
+      minimumMatchTerms: req.body['minimumMatchTerms'],
+    });
     reply.status(200).send(result);
   },
 });

--- a/src/use-cases/FindDocuments.test.ts
+++ b/src/use-cases/FindDocuments.test.ts
@@ -6,10 +6,11 @@ describe('Find Documents Use Case', () => {
     { name: '123.jpeg', id: '123' },
     { name: '456.pdf', id: '456' },
   ];
+  const findDocuments = jest.fn(() => Promise.resolve(documents));
 
   const usecase = new FindDocuments({
     elasticsearchGateway: ({
-      findDocuments: jest.fn(() => Promise.resolve(documents)),
+      findDocuments,
     } as unknown) as ElasticsearchGateway,
   });
 
@@ -20,6 +21,19 @@ describe('Find Documents Use Case', () => {
       lastName: 'Jones',
     };
     const result = await usecase.execute({ metadata });
+    expect(findDocuments).toHaveBeenCalledWith({ metadata });
     expect(result).toEqual(expectedResult);
+  });
+
+  it('can request minimum matching terms', async () => {
+    const metadata = {
+      firstName: 'Tim',
+      lastName: 'Jones',
+    };
+    await usecase.execute({ metadata, minimumMatchTerms: 2 });
+    expect(findDocuments).toHaveBeenCalledWith({
+      metadata,
+      minimumMatchTerms: 2,
+    });
   });
 });

--- a/src/use-cases/FindDocuments.ts
+++ b/src/use-cases/FindDocuments.ts
@@ -8,6 +8,7 @@ interface FindDocumentsDependencies {
 
 interface FindDocumentsCommand {
   metadata: Omit<DocumentMetadata, 'documentId'>;
+  minimumMatchTerms?: Number;
 }
 
 interface FindDocumentsResult {
@@ -24,10 +25,12 @@ export default class FindDocumentsUseCase
 
   async execute({
     metadata,
+    minimumMatchTerms,
   }: FindDocumentsCommand): Promise<FindDocumentsResult> {
     return {
       documents: await this.elasticsearchGateway.findDocuments({
         metadata,
+        minimumMatchTerms,
       }),
     };
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": ["es2019"],
     "module": "commonjs",
     "outDir": "out",
     "sourceMap": true


### PR DESCRIPTION
**What**  
Update the search query so that it does partial matches and allows both searching in arrays and straight string matching. Add minimum match terms to allow for cases where we want more than one metadata key/value to match.

**Why**  
We need partial record matching

**Anything else?**
Doc upload tool and SV requests will both need updating after this (search request body has changed shape)